### PR TITLE
Adicionando Id do attendee que faltou

### DIFF
--- a/src/routes/get-attendee-badge.ts
+++ b/src/routes/get-attendee-badge.ts
@@ -17,6 +17,7 @@ export async function getAttendeeBadge(app: FastifyInstance) {
         response: {
           200: z.object({
             badge: z.object({
+              id: z.number(),
               name: z.string(),
               email: z.string().email(),
               eventTitle: z.string(),
@@ -30,6 +31,7 @@ export async function getAttendeeBadge(app: FastifyInstance) {
 
       const attendee = await prisma.attendee.findUnique({
         select: {
+          id: true,
           name: true,
           email: true,
           event: {
@@ -53,6 +55,7 @@ export async function getAttendeeBadge(app: FastifyInstance) {
 
       return reply.send({
         badge: {
+          id: attendee.id,
           name: attendee.name,
           email: attendee.email,
           eventTitle: attendee.event.title,


### PR DESCRIPTION
Estava dando problema na credencial do aplicativo feito da trilha de React Native.
O ID não era puchado do backend por não estar enviando o ID do attendee.
Ele não puxava essa informação no `credential.tsx`
nessa parte:
### Front:
```ts
 <Text className="text-zinc-50 text-sm font-bold">#{data.id}</Text>
```

### Back:
```ts
return reply.send({
        badge: {
            id: attendee.id,  // Estava faltando essa parte do Beckend
          name: attendee.name,
          email: attendee.email,
          eventTitle: attendee.event.title,
          checkInURL: checkInURL.toString(),
        }
      })
```
### Antes e depois:
<img src="https://github.com/rocketseat-education/nlw-unite-nodejs/assets/78518664/dafeb852-ad46-4ca3-8473-6cd49baa3ffd" alt="antes" width="300">
|____|
<img src="https://github.com/rocketseat-education/nlw-unite-nodejs/assets/78518664/d8106ffc-1fa7-4c79-99c9-9939bcf584ff" alt="depois" width="300">



